### PR TITLE
Fix colour contrast issue on archive tag count

### DIFF
--- a/src/styles/partials/_tag_list.scss
+++ b/src/styles/partials/_tag_list.scss
@@ -18,6 +18,10 @@
       &:focus {
         background: var(--link-color);
         color: var(--background-color);
+
+        .count {
+          color: var(--background-color);
+        }
       }
 
       .count {


### PR DESCRIPTION
Hey Łukasz! I've been enjoying using this blog template, it is a huge head start. I've tried building my own blog with Eleventy a few times but never got as far as setting up tags + RSS plus so many of the features you've implemented.

I just noticed a colour contrast issue when you hover over tag links on the archive page - while the tag name changes colour, the count stays grey:
![screenshot of tags with one hovered - shows light grey text against light blue background](https://github.com/lwojcik/eleventy-template-bliss/assets/10627494/aeb5c89d-9d31-4320-879b-440b96fb343f)

I've fixed that in this commit, just by adding a few lines to the tag list SCSS file.

Thanks again :)