### PR TITLE
Accessibility fix: associate mastodon instance input with label

### DIFF
--- a/content/_includes/partials/post/mastodon-share-dialog.njk
+++ b/content/_includes/partials/post/mastodon-share-dialog.njk
@@ -1,10 +1,11 @@
 <div class="mastodon-share-dialog">
-  <p><b>{{ phrases.which_instance }}</b></p>
+  <p id="which-instance-label"><b>{{ phrases.which_instance }}</b></p>
   <p>{{ phrases.mastodon_share_line_1 }}</p>
   <p>{{ phrases.mastodon_share_line_2 }}</p>
   <p>{{ phrases.example }}: <code>{{ phrases.sample_instance }}</code></p>
   <form class="mastodon-share-form">
-    <input type="text" class="instance-url-input" />
+    <input type="text" class="instance-url-input"
+    aria-labelledby="which-instance-label" />
     <input class="share-form-submit" type="submit" value="{{ phrases.share }}" disabled />
   </form>
   <p><span class="close-link" tabindex="0">{{ phrases.close_window }}</span></p>


### PR DESCRIPTION
Hi again Łukasz! Today I've been experimenting with using the [pa11y](https://github.com/pa11y/pa11y) CLI tool to run accessibility tests after the Eleventy build process finishes. [I'm working on making that into an Eleventy plugin](https://github.com/larryhudson/11ty-blog-bliss/blob/pa11y/_11ty/plugins/pa11y.js).

While I was testing it, it picked up an accessibility issue with the Mastodon sharing prompt window (which is a great addition by the way!) - the input for entering your instance doesn't have an associated label. I've fixed that by adding an id to the 'which instance' heading and then added 'aria-labelledby' to the input to link them up. This means the issue is solved without needing to add an extra visible label to the input and changing it visually.

Hope you don't mind me submitting these changes - let me know if they're annoying! Thanks :)