### PR TITLE
Remove third-party dependencies from GitHub Actions workflow

### DIFF
--- a/.github/workflows/build-to-gh-pages.yml
+++ b/.github/workflows/build-to-gh-pages.yml
@@ -1,28 +1,54 @@
 name: Build and deploy to GitHub Pages
 
 on:
+# Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+permissions:
+  contents: write
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment
+concurrency:
+  group: 'pages'
+  cancel-in-progress: true
+
 jobs:
-  BuildEleventy:
+  # Build job
+  build:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
-      - name: Use Node.js LTS
+      - name: Setup Node
         uses: actions/setup-node@v4
         with:
           node-version: 'node'
           check-latest: true
+
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
 
       - name: Install dependencies & build
         run: |
           npm install
           npm run build-gh-pages
 
-      - name: Deploy
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          publish_dir: ./_site
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_branch: gh-pages
+          path: ./_site
+
+  # Deployment job
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -54,27 +54,12 @@ Render:
 Follow the steps below:
 
 1. Fork the repository to your GitHub account.
-2. In `package.json`, find the following line:
-
-```json
-{
-  "scripts": {
-    // ...
-    "build-gh-pages": "npm run build:sass; npm run build:eleventy -- --pathprefix=/eleventy-template-bliss/",
-    //...
-  }
-}
-```
-
-Replace `eleventy-template-bliss` with the name of your repository.
-
-3. In your repository, make sure GitHub Pages are set up in the _Pages_ tab of your repository settings:
-   - **Source** - should be set up to _Deploy from a branch_
-   - **Branch** - add a branch called `gh-pages`
-4. In `Actions > General` tab, in the _Workflow permissions_ section, select `Read and write permissions`
-5. Go to `Actions` tabs of your repository. From the list of actions select `Build and deploy to GitHub Pages`
-6. Click `Run workflow`.
-7. If the workflow runs successfully, your page will be available at `https://yourusername.github.io/your-repo-name`.
+1. In your repository, make sure GitHub Pages are set up in the _Pages_ tab of your repository settings:
+   - **Source** - should be set up to _GitHub Actions_
+1. In `Actions > General` section of your repository's settings, under the _Workflow permissions_ sub-section, select `Read and write permissions`
+1. Go to `Actions` tabs of your repository. From the list of actions select `Build and deploy to GitHub Pages`
+1. Click `Run workflow`.
+1. If the workflow runs successfully, your page will be available at `https://yourusername.github.io/your-repo-name`.
 
 By default, the GitHub action workflow for publishing on GitHub Pages is set to be run manually. If you want it to run on each push to `main` branch, open `.github/workflows/build-to-gh-pages.yml` and edit `on` section as follows:
 

--- a/README.md
+++ b/README.md
@@ -54,12 +54,26 @@ Render:
 Follow the steps below:
 
 1. Fork the repository to your GitHub account.
-1. In your repository, make sure GitHub Pages are set up in the _Pages_ tab of your repository settings:
+2. In `package.json`, find the following line:
+
+```json
+{
+  "scripts": {
+    // ...
+    "build-gh-pages": "npm run build:sass; npm run build:eleventy -- --pathprefix=/eleventy-template-bliss/",
+    //...
+  }
+}
+```
+
+Replace `eleventy-template-bliss` with the name of your repository.
+
+3. In your repository, make sure GitHub Pages are set up in the _Pages_ tab of your repository settings:
    - **Source** - should be set up to _GitHub Actions_
-1. In `Actions > General` section of your repository's settings, under the _Workflow permissions_ sub-section, select `Read and write permissions`
-1. Go to `Actions` tabs of your repository. From the list of actions select `Build and deploy to GitHub Pages`
-1. Click `Run workflow`.
-1. If the workflow runs successfully, your page will be available at `https://yourusername.github.io/your-repo-name`.
+4. In `Actions > General` section of your repository's settings, under the _Workflow permissions_ sub-section, select `Read and write permissions`
+5. Go to `Actions` tabs of your repository. From the list of actions select `Build and deploy to GitHub Pages`
+6. Click `Run workflow`.
+7. If the workflow runs successfully, your page will be available at `https://yourusername.github.io/your-repo-name`.
 
 By default, the GitHub action workflow for publishing on GitHub Pages is set to be run manually. If you want it to run on each push to `main` branch, open `.github/workflows/build-to-gh-pages.yml` and edit `on` section as follows:
 


### PR DESCRIPTION
Use modern GitHub Actions deployment method for GitHub Pages