### PR TITLE
Fix pagination bug

### DIFF
--- a/src/scripts/scripts.js
+++ b/src/scripts/scripts.js
@@ -222,7 +222,7 @@ window.addEventListener('DOMContentLoaded', () => {
       .split(/\/[0-9]+\//)[0]
       .replace(/\/+$/, '');
 
-    const newLocation = pageNumber === 1 ? pageUrl : `${pageUrl}/${pageNumber}`;
+    const newLocation = pageNumber === 1 ? pageUrl : `${pageUrl}/${pageNumber}/`;
 
     window.location.href = newLocation;
   };


### PR DESCRIPTION
add trailing slash to `newLocation`

allows setting `window.location.href` value behind CDNs such as AWS CloudFront